### PR TITLE
lbrytools: more information on the `lbrytools` suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ A list of community run projects built on and for the LBRY protocol.
 - [Hound.fm](https://hound.fm) - [GitHub](https://github.com/Hound-fm/web) - Discover music and podcasts.
 
 ## Tools
-- [lbryseed](https://github.com/belikor/lbrydseed) - Graphical interface to download and seed content to the LBRY network.
+- [lbrytools](https://github.com/belikor/lbrytools) - A Python library with various methods built on top of the terminal `lbrynet` client. It includes methods to download and manage multiple claims, list downloaded claims, list the existing blobs, add, remove and change the support to claims, calculate the seeding ratio, and others. It includes various tools inspired by [Brendon Brewer](https://odysee.com/$/list/3a8c64f781ab2ed2d17f8f808c708a5ee0b04423), tuxfoo, miko, and other members of the community.
+- [zeedit](https://github.com/belikor/zeedit) - A terminal program to download claims from specific channels by using a configuration file. This program can be used in a headless server to create a seedbox. It is based on [lbrytools](https://github.com/belikor/lbrytools).
+- [lbrydseed](https://github.com/belikor/lbrydseed) - Graphical interface to perform various actions on the LBRY network. It is basically a graphical interface to many methods of the [lbrytools](https://github.com/belikor/lbrytools) library.
 - [lbt](https://gitlab.com/gardenappl/lbt) - lbt is a collection of command-line tools for interacting with the LBRY network, written in POSIX shell.
-- [lbrytools](https://github.com/belikor/lbrytools) - A library of functions that can be used to manage the download of claims from the LBRY network. It includes methods to download claims by URI (canonical url), claim ID, or from specific channels.
 - [Email Over Blockchain](https://github.com/mlibre/email-on-blockchain) - Uses the LBRY blockchain to allow you to send emails as claims. 
 - [wol-api](https://github.com/devbrones/wol-api) - WOL-API (API for future impl. in Watch-on-LBRY)
 - [Podcatcher](https://github.com/Hound-fm/podcatcher) - An open source audio media crawler for lbry. Helps you discover music and podcasts.


### PR DESCRIPTION
- The base Python library is `lbrytools`.
- `zeedit`, which is based on `lbrytools`, is now in its own repository, and thus it is listed in its own entry.
- `lbrydseed` is basically a graphical interface to `lbrytools`.